### PR TITLE
Fix big QQuickItem leak

### DIFF
--- a/movierenderer.cpp
+++ b/movierenderer.cpp
@@ -160,6 +160,9 @@ void MovieRenderer::start()
 
 void MovieRenderer::cleanup()
 {
+    delete m_rootItem;
+    m_rootItem = nullptr;
+
     m_animationDriver->uninstall();
     delete m_animationDriver;
     m_animationDriver = nullptr;
@@ -181,6 +184,9 @@ void MovieRenderer::destroyFbo()
 
 bool MovieRenderer::loadQML(const QString &qmlFile, const QSize &size)
 {
+    delete m_rootItem;
+    m_rootItem = nullptr;
+
     if (m_qmlComponent != nullptr)
         delete m_qmlComponent;
     m_qmlComponent = new QQmlComponent(m_qmlEngine, QUrl(qmlFile), QQmlComponent::PreferSynchronous);


### PR DESCRIPTION
Each time another movie was rendered, the old QML component remained
loaded. The new one was just appended to the scene. Not only was this
a memory leak, if the QML file was less than fully opaque, you could
see both components at the same time!